### PR TITLE
Update OutOptions.cs

### DIFF
--- a/src/PandocNet/Output/OutOptions.cs
+++ b/src/PandocNet/Output/OutOptions.cs
@@ -52,7 +52,7 @@ public abstract class OutOptions
 
         if (Wrap != null)
         {
-            yield return $"--wrap=={Wrap.Value.ToString().ToLower()}";
+            yield return $"--wrap={Wrap.Value.ToString().ToLower()}";
         }
 
         if (Dpi != null)


### PR DESCRIPTION
Typo with `wrap` option:
As in pandoc manual,
```plain
--wrap=auto|none|preserve
```
and not `--wrap==auto|none|preserve`