### PR TITLE
Add --variable-json, --metadata, and --metadata-file writer options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -421,12 +421,17 @@ public abstract class InOptions
     /// https://pandoc.org/MANUAL.html#option--lua-filter
     /// </summary>
     public string? LuaFilter { get; set; }
-    //TODO:--metadata
     /// <summary>
     /// Set the metadata field KEY to the value VAL. A value specified on the command line overrides a value specified in the document using YAML metadata blocks. Values will be parsed as YAML boolean or string values. If no value is specified, the value will be treated as Boolean true.
     /// https://pandoc.org/MANUAL.html#option--metadata
     /// </summary>
-    public string? Metadata { get; set; }
+    public IDictionary<string, string>? Metadata { get; set; }
+
+    /// <summary>
+    /// Read metadata from the supplied YAML (or JSON) file.
+    /// https://pandoc.org/MANUAL.html#option--metadata-file
+    /// </summary>
+    public string? MetadataFile { get; set; }
     /// <summary>
     /// Extract images and other media contained in or linked from the source document to the path DIR, creating it if necessary, and adjust the images references in the document so they point to the extracted files.
     /// https://pandoc.org/MANUAL.html#option--extract-media
@@ -471,7 +476,15 @@ public abstract class InOptions
 
         if (Metadata != null)
         {
-            yield return $"--metadata-file={Metadata}";
+            foreach (var (key, value) in Metadata)
+            {
+                yield return $"--metadata={key}:{value}";
+            }
+        }
+
+        if (MetadataFile != null)
+        {
+            yield return $"--metadata-file={MetadataFile}";
         }
 
         if (PreserveTabs)
@@ -1549,7 +1562,7 @@ public class Epub2Out :
     /// Look in the specified XML file for metadata for the EPUB.
     /// https://pandoc.org/MANUAL.html#option--epub-metadata
     /// </summary>
-    public string? Metadata { get; set; }
+    public string? EpubMetadata { get; set; }
     /// <summary>
     /// Specify the subdirectory in the OCF container that is to hold the EPUB-specific contents
     /// https://pandoc.org/MANUAL.html#option--epub-subdirectory
@@ -1590,9 +1603,9 @@ public class Epub2Out :
         {
             yield return $"--epub-cover-image={CoverImage}";
         }
-        if (Metadata != null)
+        if (EpubMetadata != null)
         {
-            yield return $"--epub-metadata={Metadata}";
+            yield return $"--epub-metadata={EpubMetadata}";
         }
         if (EmbedFont != null)
         {
@@ -1650,7 +1663,7 @@ public class Epub3Out :
     /// Look in the specified XML file for metadata for the EPUB.
     /// https://pandoc.org/MANUAL.html#option--epub-metadata
     /// </summary>
-    public string? Metadata { get; set; }
+    public string? EpubMetadata { get; set; }
 
     /// <summary>
     /// Specify the subdirectory in the OCF container that is to hold the EPUB-specific contents
@@ -1697,9 +1710,9 @@ public class Epub3Out :
             yield return $"--epub-cover-image={CoverImage}";
         }
 
-        if (Metadata != null)
+        if (EpubMetadata != null)
         {
-            yield return $"--epub-metadata={Metadata}";
+            yield return $"--epub-metadata={EpubMetadata}";
         }
 
         if (EmbedFont != null)
@@ -2394,6 +2407,24 @@ public abstract class OutOptions
     public IDictionary<string, string>? Variables { get; set; }
 
     /// <summary>
+    /// Set template variable KEY to a JSON value. Unlike --variable, this replaces rather than appends.
+    /// https://pandoc.org/MANUAL.html#option--variable-json
+    /// </summary>
+    public IDictionary<string, string>? VariablesJson { get; set; }
+
+    /// <summary>
+    /// Set the metadata field KEY to the value VAL. Values will be parsed as YAML boolean or string values.
+    /// https://pandoc.org/MANUAL.html#option--metadata
+    /// </summary>
+    public IDictionary<string, string>? Metadata { get; set; }
+
+    /// <summary>
+    /// Read metadata from the supplied YAML (or JSON) file.
+    /// https://pandoc.org/MANUAL.html#option--metadata-file
+    /// </summary>
+    public string? MetadataFile { get; set; }
+
+    /// <summary>
     /// Produce a standalone HTML file with no external dependencies, using data: URIs to incorporate the contents of linked scripts, stylesheets, images, and videos. The resulting file should be self-contained.
     /// https://pandoc.org/MANUAL.html#option--embed-resources%5B
     /// </summary>
@@ -2431,6 +2462,27 @@ public abstract class OutOptions
             {
                 yield return $"--variable={key}:{value}";
             }
+        }
+
+        if (VariablesJson != null)
+        {
+            foreach (var (key, value) in VariablesJson)
+            {
+                yield return $"--variable-json={key}:{value}";
+            }
+        }
+
+        if (Metadata != null)
+        {
+            foreach (var (key, value) in Metadata)
+            {
+                yield return $"--metadata={key}:{value}";
+            }
+        }
+
+        if (MetadataFile != null)
+        {
+            yield return $"--metadata-file={MetadataFile}";
         }
 
         if (EmbedResources)

--- a/src/PandocNet/Input/InOptions.cs
+++ b/src/PandocNet/Input/InOptions.cs
@@ -37,12 +37,17 @@ public abstract class InOptions
     /// https://pandoc.org/MANUAL.html#option--lua-filter
     /// </summary>
     public string? LuaFilter { get; set; }
-    //TODO:--metadata
     /// <summary>
     /// Set the metadata field KEY to the value VAL. A value specified on the command line overrides a value specified in the document using YAML metadata blocks. Values will be parsed as YAML boolean or string values. If no value is specified, the value will be treated as Boolean true.
     /// https://pandoc.org/MANUAL.html#option--metadata
     /// </summary>
-    public string? Metadata { get; set; }
+    public IDictionary<string, string>? Metadata { get; set; }
+
+    /// <summary>
+    /// Read metadata from the supplied YAML (or JSON) file.
+    /// https://pandoc.org/MANUAL.html#option--metadata-file
+    /// </summary>
+    public string? MetadataFile { get; set; }
     /// <summary>
     /// Extract images and other media contained in or linked from the source document to the path DIR, creating it if necessary, and adjust the images references in the document so they point to the extracted files.
     /// https://pandoc.org/MANUAL.html#option--extract-media
@@ -87,7 +92,15 @@ public abstract class InOptions
 
         if (Metadata != null)
         {
-            yield return $"--metadata-file={Metadata}";
+            foreach (var (key, value) in Metadata)
+            {
+                yield return $"--metadata={key}:{value}";
+            }
+        }
+
+        if (MetadataFile != null)
+        {
+            yield return $"--metadata-file={MetadataFile}";
         }
 
         if (PreserveTabs)

--- a/src/PandocNet/Output/Epub2Out.cs
+++ b/src/PandocNet/Output/Epub2Out.cs
@@ -32,7 +32,7 @@ public class Epub2Out :
     /// Look in the specified XML file for metadata for the EPUB.
     /// https://pandoc.org/MANUAL.html#option--epub-metadata
     /// </summary>
-    public string? Metadata { get; set; }
+    public string? EpubMetadata { get; set; }
     /// <summary>
     /// Specify the subdirectory in the OCF container that is to hold the EPUB-specific contents
     /// https://pandoc.org/MANUAL.html#option--epub-subdirectory
@@ -73,9 +73,9 @@ public class Epub2Out :
         {
             yield return $"--epub-cover-image={CoverImage}";
         }
-        if (Metadata != null)
+        if (EpubMetadata != null)
         {
-            yield return $"--epub-metadata={Metadata}";
+            yield return $"--epub-metadata={EpubMetadata}";
         }
         if (EmbedFont != null)
         {

--- a/src/PandocNet/Output/Epub3Out.cs
+++ b/src/PandocNet/Output/Epub3Out.cs
@@ -36,7 +36,7 @@ public class Epub3Out :
     /// Look in the specified XML file for metadata for the EPUB.
     /// https://pandoc.org/MANUAL.html#option--epub-metadata
     /// </summary>
-    public string? Metadata { get; set; }
+    public string? EpubMetadata { get; set; }
 
     /// <summary>
     /// Specify the subdirectory in the OCF container that is to hold the EPUB-specific contents
@@ -83,9 +83,9 @@ public class Epub3Out :
             yield return $"--epub-cover-image={CoverImage}";
         }
 
-        if (Metadata != null)
+        if (EpubMetadata != null)
         {
-            yield return $"--epub-metadata={Metadata}";
+            yield return $"--epub-metadata={EpubMetadata}";
         }
 
         if (EmbedFont != null)

--- a/src/PandocNet/Output/OutOptions.cs
+++ b/src/PandocNet/Output/OutOptions.cs
@@ -79,6 +79,24 @@ public abstract class OutOptions
     public IDictionary<string, string>? Variables { get; set; }
 
     /// <summary>
+    /// Set template variable KEY to a JSON value. Unlike --variable, this replaces rather than appends.
+    /// https://pandoc.org/MANUAL.html#option--variable-json
+    /// </summary>
+    public IDictionary<string, string>? VariablesJson { get; set; }
+
+    /// <summary>
+    /// Set the metadata field KEY to the value VAL. Values will be parsed as YAML boolean or string values.
+    /// https://pandoc.org/MANUAL.html#option--metadata
+    /// </summary>
+    public IDictionary<string, string>? Metadata { get; set; }
+
+    /// <summary>
+    /// Read metadata from the supplied YAML (or JSON) file.
+    /// https://pandoc.org/MANUAL.html#option--metadata-file
+    /// </summary>
+    public string? MetadataFile { get; set; }
+
+    /// <summary>
     /// Produce a standalone HTML file with no external dependencies, using data: URIs to incorporate the contents of linked scripts, stylesheets, images, and videos. The resulting file should be self-contained.
     /// https://pandoc.org/MANUAL.html#option--embed-resources%5B
     /// </summary>
@@ -116,6 +134,27 @@ public abstract class OutOptions
             {
                 yield return $"--variable={key}:{value}";
             }
+        }
+
+        if (VariablesJson != null)
+        {
+            foreach (var (key, value) in VariablesJson)
+            {
+                yield return $"--variable-json={key}:{value}";
+            }
+        }
+
+        if (Metadata != null)
+        {
+            foreach (var (key, value) in Metadata)
+            {
+                yield return $"--metadata={key}:{value}";
+            }
+        }
+
+        if (MetadataFile != null)
+        {
+            yield return $"--metadata-file={MetadataFile}";
         }
 
         if (EmbedResources)

--- a/src/Tests/OptionsTests.cs
+++ b/src/Tests/OptionsTests.cs
@@ -1,0 +1,99 @@
+[TestFixture]
+public class OptionsTests
+{
+    [Test]
+    public void OutVariablesJson()
+    {
+        var options = new HtmlOut
+        {
+            VariablesJson = new Dictionary<string, string>
+            {
+                { "foo", "false" },
+                { "colors", "[\"red\",\"green\"]" }
+            }
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--variable-json=foo:false"));
+        Assert.That(args, Does.Contain("--variable-json=colors:[\"red\",\"green\"]"));
+    }
+
+    [Test]
+    public void OutMetadata()
+    {
+        var options = new HtmlOut
+        {
+            Metadata = new Dictionary<string, string>
+            {
+                { "title", "My Document" },
+                { "author", "Jane" }
+            }
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--metadata=title:My Document"));
+        Assert.That(args, Does.Contain("--metadata=author:Jane"));
+    }
+
+    [Test]
+    public void OutMetadataFile()
+    {
+        var options = new HtmlOut
+        {
+            MetadataFile = "meta.yaml"
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--metadata-file=meta.yaml"));
+    }
+
+    [Test]
+    public void OutVariables()
+    {
+        var options = new HtmlOut
+        {
+            Variables = new Dictionary<string, string>
+            {
+                { "margin-top", "1in" }
+            }
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--variable=margin-top:1in"));
+    }
+
+    [Test]
+    public void InMetadata()
+    {
+        var options = new CommonMarkIn
+        {
+            Metadata = new Dictionary<string, string>
+            {
+                { "title", "Test" },
+                { "draft", "true" }
+            }
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--metadata=title:Test"));
+        Assert.That(args, Does.Contain("--metadata=draft:true"));
+    }
+
+    [Test]
+    public void InMetadataFile()
+    {
+        var options = new CommonMarkIn
+        {
+            MetadataFile = "metadata.yaml"
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--metadata-file=metadata.yaml"));
+    }
+}

--- a/src/input.include.md
+++ b/src/input.include.md
@@ -317,12 +317,17 @@ public abstract class InOptions
     /// https://pandoc.org/MANUAL.html#option--lua-filter
     /// </summary>
     public string? LuaFilter { get; set; }
-    //TODO:--metadata
     /// <summary>
     /// Set the metadata field KEY to the value VAL. A value specified on the command line overrides a value specified in the document using YAML metadata blocks. Values will be parsed as YAML boolean or string values. If no value is specified, the value will be treated as Boolean true.
     /// https://pandoc.org/MANUAL.html#option--metadata
     /// </summary>
-    public string? Metadata { get; set; }
+    public IDictionary<string, string>? Metadata { get; set; }
+
+    /// <summary>
+    /// Read metadata from the supplied YAML (or JSON) file.
+    /// https://pandoc.org/MANUAL.html#option--metadata-file
+    /// </summary>
+    public string? MetadataFile { get; set; }
     /// <summary>
     /// Extract images and other media contained in or linked from the source document to the path DIR, creating it if necessary, and adjust the images references in the document so they point to the extracted files.
     /// https://pandoc.org/MANUAL.html#option--extract-media
@@ -367,7 +372,15 @@ public abstract class InOptions
 
         if (Metadata != null)
         {
-            yield return $"--metadata-file={Metadata}";
+            foreach (var (key, value) in Metadata)
+            {
+                yield return $"--metadata={key}:{value}";
+            }
+        }
+
+        if (MetadataFile != null)
+        {
+            yield return $"--metadata-file={MetadataFile}";
         }
 
         if (PreserveTabs)

--- a/src/output.include.md
+++ b/src/output.include.md
@@ -455,7 +455,7 @@ public class Epub2Out :
     /// Look in the specified XML file for metadata for the EPUB.
     /// https://pandoc.org/MANUAL.html#option--epub-metadata
     /// </summary>
-    public string? Metadata { get; set; }
+    public string? EpubMetadata { get; set; }
     /// <summary>
     /// Specify the subdirectory in the OCF container that is to hold the EPUB-specific contents
     /// https://pandoc.org/MANUAL.html#option--epub-subdirectory
@@ -496,9 +496,9 @@ public class Epub2Out :
         {
             yield return $"--epub-cover-image={CoverImage}";
         }
-        if (Metadata != null)
+        if (EpubMetadata != null)
         {
-            yield return $"--epub-metadata={Metadata}";
+            yield return $"--epub-metadata={EpubMetadata}";
         }
         if (EmbedFont != null)
         {
@@ -556,7 +556,7 @@ public class Epub3Out :
     /// Look in the specified XML file for metadata for the EPUB.
     /// https://pandoc.org/MANUAL.html#option--epub-metadata
     /// </summary>
-    public string? Metadata { get; set; }
+    public string? EpubMetadata { get; set; }
 
     /// <summary>
     /// Specify the subdirectory in the OCF container that is to hold the EPUB-specific contents
@@ -603,9 +603,9 @@ public class Epub3Out :
             yield return $"--epub-cover-image={CoverImage}";
         }
 
-        if (Metadata != null)
+        if (EpubMetadata != null)
         {
-            yield return $"--epub-metadata={Metadata}";
+            yield return $"--epub-metadata={EpubMetadata}";
         }
 
         if (EmbedFont != null)
@@ -1300,6 +1300,24 @@ public abstract class OutOptions
     public IDictionary<string, string>? Variables { get; set; }
 
     /// <summary>
+    /// Set template variable KEY to a JSON value. Unlike --variable, this replaces rather than appends.
+    /// https://pandoc.org/MANUAL.html#option--variable-json
+    /// </summary>
+    public IDictionary<string, string>? VariablesJson { get; set; }
+
+    /// <summary>
+    /// Set the metadata field KEY to the value VAL. Values will be parsed as YAML boolean or string values.
+    /// https://pandoc.org/MANUAL.html#option--metadata
+    /// </summary>
+    public IDictionary<string, string>? Metadata { get; set; }
+
+    /// <summary>
+    /// Read metadata from the supplied YAML (or JSON) file.
+    /// https://pandoc.org/MANUAL.html#option--metadata-file
+    /// </summary>
+    public string? MetadataFile { get; set; }
+
+    /// <summary>
     /// Produce a standalone HTML file with no external dependencies, using data: URIs to incorporate the contents of linked scripts, stylesheets, images, and videos. The resulting file should be self-contained.
     /// https://pandoc.org/MANUAL.html#option--embed-resources%5B
     /// </summary>
@@ -1337,6 +1355,27 @@ public abstract class OutOptions
             {
                 yield return $"--variable={key}:{value}";
             }
+        }
+
+        if (VariablesJson != null)
+        {
+            foreach (var (key, value) in VariablesJson)
+            {
+                yield return $"--variable-json={key}:{value}";
+            }
+        }
+
+        if (Metadata != null)
+        {
+            foreach (var (key, value) in Metadata)
+            {
+                yield return $"--metadata={key}:{value}";
+            }
+        }
+
+        if (MetadataFile != null)
+        {
+            yield return $"--metadata-file={MetadataFile}";
         }
 
         if (EmbedResources)


### PR DESCRIPTION
  Complete the Variables section from issue #1 by adding VariablesJson,
  Metadata, and MetadataFile properties to OutOptions. Fix InOptions where
  the Metadata property incorrectly emitted --metadata-file instead of
  --metadata, and add a separate MetadataFile property. Rename
  Epub2Out/Epub3Out.Metadata to EpubMetadata to avoid hiding the new base
  class property.

  BREAKING: InOptions.Metadata changed from string? to IDictionary<string, string>?.
  BREAKING: Epub2Out.Metadata and Epub3Out.Metadata renamed to EpubMetadata.