### PR TITLE
Add missing pandoc CLI options and fix --file-scope bug

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -443,6 +443,12 @@ public abstract class InOptions
     /// </summary>
     public string? Abbreviations{ get; set; }
 
+    /// <summary>
+    /// Print diagnostic output tracing parser progress to stderr.
+    /// https://pandoc.org/MANUAL.html#option--trace
+    /// </summary>
+    public bool Trace { get; set; }
+
     protected abstract string Format { get; }
 
     public virtual IEnumerable<string> GetArguments()
@@ -461,7 +467,7 @@ public abstract class InOptions
 
         if (FileScope)
         {
-            yield return "file-scope";
+            yield return "--file-scope";
         }
 
         if (Filter != null)
@@ -505,6 +511,11 @@ public abstract class InOptions
         if (Abbreviations != null)
         {
             yield return $"--abbreviations={Abbreviations}";
+        }
+
+        if (Trace)
+        {
+            yield return "--trace";
         }
     }
 }
@@ -1273,6 +1284,17 @@ public class BibTeXOut :
 ```
 
 
+#### CaptionPosition
+
+```cs
+public enum CaptionPosition
+{
+    Above,
+    Below
+}
+```
+
+
 #### ChunkedHtmlOut
 
 ```cs
@@ -1283,6 +1305,36 @@ public class ChunkedHtmlOut :
     OutOptions
 {
     public override string Format => "chunkedhtml";
+
+    /// <summary>
+    /// Specify the heading level at which to split into separate chunk files.
+    /// https://pandoc.org/MANUAL.html#option--split-level
+    /// </summary>
+    public int? SplitLevel { get; set; }
+
+    /// <summary>
+    /// Specify a template for the filenames in chunked HTML output.
+    /// https://pandoc.org/MANUAL.html#option--chunk-template
+    /// </summary>
+    public string? ChunkTemplate { get; set; }
+
+    public override IEnumerable<string> GetArguments()
+    {
+        foreach (var argument in base.GetArguments())
+        {
+            yield return argument;
+        }
+
+        if (SplitLevel != null)
+        {
+            yield return $"--split-level={SplitLevel}";
+        }
+
+        if (ChunkTemplate != null)
+        {
+            yield return $"--chunk-template={ChunkTemplate}";
+        }
+    }
 }
 ```
 
@@ -1515,6 +1567,18 @@ public class EmacsOrgOut :
 ```
 
 
+#### EmailObfuscation
+
+```cs
+public enum EmailObfuscation
+{
+    None,
+    Javascript,
+    References
+}
+```
+
+
 #### Eol
 
 ```cs
@@ -1579,6 +1643,18 @@ public class Epub2Out :
     /// </summary>
     public int? ChapterLevel { get; set; }
 
+    /// <summary>
+    /// Specify the heading level at which to split the EPUB into separate files.
+    /// https://pandoc.org/MANUAL.html#option--split-level
+    /// </summary>
+    public int? SplitLevel { get; set; }
+
+    /// <summary>
+    /// Determines whether a title page is included in the EPUB.
+    /// https://pandoc.org/MANUAL.html#option--epub-title-page
+    /// </summary>
+    public bool? EpubTitlePage { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -1618,6 +1694,14 @@ public class Epub2Out :
         if (SubDirectory != null)
         {
             yield return $"--epub-subdirectory={SubDirectory}";
+        }
+        if (SplitLevel != null)
+        {
+            yield return $"--split-level={SplitLevel}";
+        }
+        if (EpubTitlePage != null)
+        {
+            yield return $"--epub-title-page={EpubTitlePage.Value.ToString().ToLower()}";
         }
     }
 }
@@ -1683,6 +1767,18 @@ public class Epub3Out :
     /// </summary>
     public int? ChapterLevel { get; set; }
 
+    /// <summary>
+    /// Specify the heading level at which to split the EPUB into separate files.
+    /// https://pandoc.org/MANUAL.html#option--split-level
+    /// </summary>
+    public int? SplitLevel { get; set; }
+
+    /// <summary>
+    /// Determines whether a title page is included in the EPUB.
+    /// https://pandoc.org/MANUAL.html#option--epub-title-page
+    /// </summary>
+    public bool? EpubTitlePage { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -1728,6 +1824,16 @@ public class Epub3Out :
         if (SubDirectory != null)
         {
             yield return $"--epub-subdirectory={SubDirectory}";
+        }
+
+        if (SplitLevel != null)
+        {
+            yield return $"--split-level={SplitLevel}";
+        }
+
+        if (EpubTitlePage != null)
+        {
+            yield return $"--epub-title-page={EpubTitlePage.Value.ToString().ToLower()}";
         }
     }
 }
@@ -1869,6 +1975,12 @@ public class HtmlOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -1924,6 +2036,11 @@ public class HtmlOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }
@@ -2347,6 +2464,37 @@ public abstract class OutOptions
     public bool Sandbox { get; set; }
     public bool TableOfContents { get; set; }
     public int? TableOfContentsDepth { get; set; }
+
+    /// <summary>
+    /// Include an automatically generated list of figures.
+    /// https://pandoc.org/MANUAL.html#option--list-of-figures
+    /// </summary>
+    public bool ListOfFigures { get; set; }
+
+    /// <summary>
+    /// Include an automatically generated list of tables.
+    /// https://pandoc.org/MANUAL.html#option--list-of-tables
+    /// </summary>
+    public bool ListOfTables { get; set; }
+
+    /// <summary>
+    /// Specify where figure captions are placed relative to figures.
+    /// https://pandoc.org/MANUAL.html#option--figure-caption-position
+    /// </summary>
+    public CaptionPosition? FigureCaptionPosition { get; set; }
+
+    /// <summary>
+    /// Specify where table captions are placed relative to tables.
+    /// https://pandoc.org/MANUAL.html#option--table-caption-position
+    /// </summary>
+    public CaptionPosition? TableCaptionPosition { get; set; }
+
+    /// <summary>
+    /// Specify the method to use for code syntax highlighting.
+    /// https://pandoc.org/MANUAL.html#option--syntax-highlighting
+    /// </summary>
+    public string? SyntaxHighlighting { get; set; }
+
     public Eol? Eol { get; set; }
     public Wrap? Wrap { get; set; }
     public int? Dpi { get; set; }
@@ -2526,6 +2674,26 @@ public abstract class OutOptions
         {
             yield return $"--toc-depth={TableOfContentsDepth}";
         }
+        if (ListOfFigures)
+        {
+            yield return "--list-of-figures";
+        }
+        if (ListOfTables)
+        {
+            yield return "--list-of-tables";
+        }
+        if (FigureCaptionPosition != null)
+        {
+            yield return $"--figure-caption-position={FigureCaptionPosition.Value.ToString().ToLower()}";
+        }
+        if (TableCaptionPosition != null)
+        {
+            yield return $"--table-caption-position={TableCaptionPosition.Value.ToString().ToLower()}";
+        }
+        if (SyntaxHighlighting != null)
+        {
+            yield return $"--syntax-highlighting={SyntaxHighlighting}";
+        }
         if (StripComments)
         {
             yield return "--strip-comments";
@@ -2698,6 +2866,12 @@ public class RstOut :
     /// </summary>
     public bool ReferenceLinks { get; set; }
 
+    /// <summary>
+    /// Render tables as RST list tables.
+    /// https://pandoc.org/MANUAL.html#option--list-tables
+    /// </summary>
+    public bool ListTables { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -2708,6 +2882,11 @@ public class RstOut :
         if (ReferenceLinks)
         {
             yield return "--reference-links";
+        }
+
+        if (ListTables)
+        {
+            yield return "--list-tables";
         }
     }
 }
@@ -3405,6 +3584,12 @@ public class PdfOut :
     /// </remarks>
     public string? EnginePath { get; set; }
 
+    /// <summary>
+    /// Pass the given string as a command-line argument to the pdf-engine.
+    /// https://pandoc.org/MANUAL.html#option--pdf-engine-opt
+    /// </summary>
+    public string? EngineOpt { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -3419,6 +3604,11 @@ public class PdfOut :
         else if (Engine != null)
         {
             yield return $"--pdf-engine={Engine.Value.ToString().ToLower()}";
+        }
+
+        if (EngineOpt != null)
+        {
+            yield return $"--pdf-engine-opt={EngineOpt}";
         }
     }
 }
@@ -3625,6 +3815,12 @@ public class DzSlidesOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -3673,6 +3869,10 @@ public class DzSlidesOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }
@@ -3764,6 +3964,12 @@ public class RevealJsOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -3804,6 +4010,10 @@ public class RevealJsOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }
@@ -3867,6 +4077,12 @@ public class S5Out :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -3911,6 +4127,10 @@ public class S5Out :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }
@@ -3974,6 +4194,12 @@ public class SlideousOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -4018,6 +4244,10 @@ public class SlideousOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }
@@ -4081,6 +4311,12 @@ public class SlidyOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -4130,6 +4366,10 @@ public class SlidyOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }

--- a/src/PandocNet/Input/InOptions.cs
+++ b/src/PandocNet/Input/InOptions.cs
@@ -59,6 +59,12 @@ public abstract class InOptions
     /// </summary>
     public string? Abbreviations{ get; set; }
 
+    /// <summary>
+    /// Print diagnostic output tracing parser progress to stderr.
+    /// https://pandoc.org/MANUAL.html#option--trace
+    /// </summary>
+    public bool Trace { get; set; }
+
     protected abstract string Format { get; }
 
     public virtual IEnumerable<string> GetArguments()
@@ -77,7 +83,7 @@ public abstract class InOptions
 
         if (FileScope)
         {
-            yield return "file-scope";
+            yield return "--file-scope";
         }
 
         if (Filter != null)
@@ -121,6 +127,11 @@ public abstract class InOptions
         if (Abbreviations != null)
         {
             yield return $"--abbreviations={Abbreviations}";
+        }
+
+        if (Trace)
+        {
+            yield return "--trace";
         }
     }
 }

--- a/src/PandocNet/Options.cs
+++ b/src/PandocNet/Options.cs
@@ -20,6 +20,24 @@ public class Options
     /// </summary>
     public string? LogFile { get; set; }
 
+    /// <summary>
+    /// Give verbose debugging output.
+    /// https://pandoc.org/MANUAL.html#option--verbose
+    /// </summary>
+    public bool Verbose { get; set; }
+
+    /// <summary>
+    /// Suppress warning messages.
+    /// https://pandoc.org/MANUAL.html#option--quiet
+    /// </summary>
+    public bool Quiet { get; set; }
+
+    /// <summary>
+    /// Exit with error status if there are any warnings.
+    /// https://pandoc.org/MANUAL.html#option--fail-if-warnings
+    /// </summary>
+    public bool FailIfWarnings { get; set; }
+
     public static IEnumerable<string> GetArguments(Options? options)
     {
         if (options == null)
@@ -40,6 +58,21 @@ public class Options
         if (options.LogFile != null)
         {
             yield return $"--log={options.LogFile}";
+        }
+
+        if (options.Verbose)
+        {
+            yield return "--verbose";
+        }
+
+        if (options.Quiet)
+        {
+            yield return "--quiet";
+        }
+
+        if (options.FailIfWarnings)
+        {
+            yield return "--fail-if-warnings";
         }
     }
 }

--- a/src/PandocNet/Output/CaptionPosition.cs
+++ b/src/PandocNet/Output/CaptionPosition.cs
@@ -1,0 +1,7 @@
+namespace Pandoc;
+
+public enum CaptionPosition
+{
+    Above,
+    Below
+}

--- a/src/PandocNet/Output/ChunkedHtmlOut.cs
+++ b/src/PandocNet/Output/ChunkedHtmlOut.cs
@@ -7,4 +7,34 @@ public class ChunkedHtmlOut :
     OutOptions
 {
     public override string Format => "chunkedhtml";
+
+    /// <summary>
+    /// Specify the heading level at which to split into separate chunk files.
+    /// https://pandoc.org/MANUAL.html#option--split-level
+    /// </summary>
+    public int? SplitLevel { get; set; }
+
+    /// <summary>
+    /// Specify a template for the filenames in chunked HTML output.
+    /// https://pandoc.org/MANUAL.html#option--chunk-template
+    /// </summary>
+    public string? ChunkTemplate { get; set; }
+
+    public override IEnumerable<string> GetArguments()
+    {
+        foreach (var argument in base.GetArguments())
+        {
+            yield return argument;
+        }
+
+        if (SplitLevel != null)
+        {
+            yield return $"--split-level={SplitLevel}";
+        }
+
+        if (ChunkTemplate != null)
+        {
+            yield return $"--chunk-template={ChunkTemplate}";
+        }
+    }
 }

--- a/src/PandocNet/Output/EmailObfuscation.cs
+++ b/src/PandocNet/Output/EmailObfuscation.cs
@@ -1,0 +1,8 @@
+namespace Pandoc;
+
+public enum EmailObfuscation
+{
+    None,
+    Javascript,
+    References
+}

--- a/src/PandocNet/Output/Epub2Out.cs
+++ b/src/PandocNet/Output/Epub2Out.cs
@@ -49,6 +49,18 @@ public class Epub2Out :
     /// </summary>
     public int? ChapterLevel { get; set; }
 
+    /// <summary>
+    /// Specify the heading level at which to split the EPUB into separate files.
+    /// https://pandoc.org/MANUAL.html#option--split-level
+    /// </summary>
+    public int? SplitLevel { get; set; }
+
+    /// <summary>
+    /// Determines whether a title page is included in the EPUB.
+    /// https://pandoc.org/MANUAL.html#option--epub-title-page
+    /// </summary>
+    public bool? EpubTitlePage { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -88,6 +100,14 @@ public class Epub2Out :
         if (SubDirectory != null)
         {
             yield return $"--epub-subdirectory={SubDirectory}";
+        }
+        if (SplitLevel != null)
+        {
+            yield return $"--split-level={SplitLevel}";
+        }
+        if (EpubTitlePage != null)
+        {
+            yield return $"--epub-title-page={EpubTitlePage.Value.ToString().ToLower()}";
         }
     }
 }

--- a/src/PandocNet/Output/Epub3Out.cs
+++ b/src/PandocNet/Output/Epub3Out.cs
@@ -56,6 +56,18 @@ public class Epub3Out :
     /// </summary>
     public int? ChapterLevel { get; set; }
 
+    /// <summary>
+    /// Specify the heading level at which to split the EPUB into separate files.
+    /// https://pandoc.org/MANUAL.html#option--split-level
+    /// </summary>
+    public int? SplitLevel { get; set; }
+
+    /// <summary>
+    /// Determines whether a title page is included in the EPUB.
+    /// https://pandoc.org/MANUAL.html#option--epub-title-page
+    /// </summary>
+    public bool? EpubTitlePage { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -101,6 +113,16 @@ public class Epub3Out :
         if (SubDirectory != null)
         {
             yield return $"--epub-subdirectory={SubDirectory}";
+        }
+
+        if (SplitLevel != null)
+        {
+            yield return $"--split-level={SplitLevel}";
+        }
+
+        if (EpubTitlePage != null)
+        {
+            yield return $"--epub-title-page={EpubTitlePage.Value.ToString().ToLower()}";
         }
     }
 }

--- a/src/PandocNet/Output/HtmlOut.cs
+++ b/src/PandocNet/Output/HtmlOut.cs
@@ -65,6 +65,12 @@ public class HtmlOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -120,6 +126,11 @@ public class HtmlOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }

--- a/src/PandocNet/Output/OutOptions.cs
+++ b/src/PandocNet/Output/OutOptions.cs
@@ -19,6 +19,37 @@ public abstract class OutOptions
     public bool Sandbox { get; set; }
     public bool TableOfContents { get; set; }
     public int? TableOfContentsDepth { get; set; }
+
+    /// <summary>
+    /// Include an automatically generated list of figures.
+    /// https://pandoc.org/MANUAL.html#option--list-of-figures
+    /// </summary>
+    public bool ListOfFigures { get; set; }
+
+    /// <summary>
+    /// Include an automatically generated list of tables.
+    /// https://pandoc.org/MANUAL.html#option--list-of-tables
+    /// </summary>
+    public bool ListOfTables { get; set; }
+
+    /// <summary>
+    /// Specify where figure captions are placed relative to figures.
+    /// https://pandoc.org/MANUAL.html#option--figure-caption-position
+    /// </summary>
+    public CaptionPosition? FigureCaptionPosition { get; set; }
+
+    /// <summary>
+    /// Specify where table captions are placed relative to tables.
+    /// https://pandoc.org/MANUAL.html#option--table-caption-position
+    /// </summary>
+    public CaptionPosition? TableCaptionPosition { get; set; }
+
+    /// <summary>
+    /// Specify the method to use for code syntax highlighting.
+    /// https://pandoc.org/MANUAL.html#option--syntax-highlighting
+    /// </summary>
+    public string? SyntaxHighlighting { get; set; }
+
     public Eol? Eol { get; set; }
     public Wrap? Wrap { get; set; }
     public int? Dpi { get; set; }
@@ -197,6 +228,26 @@ public abstract class OutOptions
         if (TableOfContentsDepth != null)
         {
             yield return $"--toc-depth={TableOfContentsDepth}";
+        }
+        if (ListOfFigures)
+        {
+            yield return "--list-of-figures";
+        }
+        if (ListOfTables)
+        {
+            yield return "--list-of-tables";
+        }
+        if (FigureCaptionPosition != null)
+        {
+            yield return $"--figure-caption-position={FigureCaptionPosition.Value.ToString().ToLower()}";
+        }
+        if (TableCaptionPosition != null)
+        {
+            yield return $"--table-caption-position={TableCaptionPosition.Value.ToString().ToLower()}";
+        }
+        if (SyntaxHighlighting != null)
+        {
+            yield return $"--syntax-highlighting={SyntaxHighlighting}";
         }
         if (StripComments)
         {

--- a/src/PandocNet/Output/Pdf/PdfOut.cs
+++ b/src/PandocNet/Output/Pdf/PdfOut.cs
@@ -24,6 +24,12 @@ public class PdfOut :
     /// </remarks>
     public string? EnginePath { get; set; }
 
+    /// <summary>
+    /// Pass the given string as a command-line argument to the pdf-engine.
+    /// https://pandoc.org/MANUAL.html#option--pdf-engine-opt
+    /// </summary>
+    public string? EngineOpt { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -38,6 +44,11 @@ public class PdfOut :
         else if (Engine != null)
         {
             yield return $"--pdf-engine={Engine.Value.ToString().ToLower()}";
+        }
+
+        if (EngineOpt != null)
+        {
+            yield return $"--pdf-engine-opt={EngineOpt}";
         }
     }
 }

--- a/src/PandocNet/Output/RstOut.cs
+++ b/src/PandocNet/Output/RstOut.cs
@@ -13,6 +13,12 @@ public class RstOut :
     /// </summary>
     public bool ReferenceLinks { get; set; }
 
+    /// <summary>
+    /// Render tables as RST list tables.
+    /// https://pandoc.org/MANUAL.html#option--list-tables
+    /// </summary>
+    public bool ListTables { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -23,6 +29,11 @@ public class RstOut :
         if (ReferenceLinks)
         {
             yield return "--reference-links";
+        }
+
+        if (ListTables)
+        {
+            yield return "--list-tables";
         }
     }
 }

--- a/src/PandocNet/Output/Slides/DzSlidesOut.cs
+++ b/src/PandocNet/Output/Slides/DzSlidesOut.cs
@@ -59,6 +59,12 @@ public class DzSlidesOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -107,6 +113,10 @@ public class DzSlidesOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }

--- a/src/PandocNet/Output/Slides/RevealJsOut.cs
+++ b/src/PandocNet/Output/Slides/RevealJsOut.cs
@@ -49,6 +49,12 @@ public class RevealJsOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -89,6 +95,10 @@ public class RevealJsOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }

--- a/src/PandocNet/Output/Slides/S5Out.cs
+++ b/src/PandocNet/Output/Slides/S5Out.cs
@@ -54,6 +54,12 @@ public class S5Out :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -98,6 +104,10 @@ public class S5Out :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }

--- a/src/PandocNet/Output/Slides/SlideousOut.cs
+++ b/src/PandocNet/Output/Slides/SlideousOut.cs
@@ -54,6 +54,12 @@ public class SlideousOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -98,6 +104,10 @@ public class SlideousOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }

--- a/src/PandocNet/Output/Slides/SlidyOut.cs
+++ b/src/PandocNet/Output/Slides/SlidyOut.cs
@@ -54,6 +54,12 @@ public class SlidyOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -103,6 +109,10 @@ public class SlidyOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }

--- a/src/Tests/OptionsTests.cs
+++ b/src/Tests/OptionsTests.cs
@@ -96,4 +96,212 @@ public class OptionsTests
 
         Assert.That(args, Does.Contain("--metadata-file=metadata.yaml"));
     }
+
+    [Test]
+    public void InFileScope()
+    {
+        var options = new CommonMarkIn
+        {
+            FileScope = true
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--file-scope"));
+    }
+
+    [Test]
+    public void InTrace()
+    {
+        var options = new CommonMarkIn
+        {
+            Trace = true
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--trace"));
+    }
+
+    [Test]
+    public void GlobalVerbose()
+    {
+        var args = Options.GetArguments(new Options { Verbose = true }).ToList();
+
+        Assert.That(args, Does.Contain("--verbose"));
+    }
+
+    [Test]
+    public void GlobalQuiet()
+    {
+        var args = Options.GetArguments(new Options { Quiet = true }).ToList();
+
+        Assert.That(args, Does.Contain("--quiet"));
+    }
+
+    [Test]
+    public void GlobalFailIfWarnings()
+    {
+        var args = Options.GetArguments(new Options { FailIfWarnings = true }).ToList();
+
+        Assert.That(args, Does.Contain("--fail-if-warnings"));
+    }
+
+    [Test]
+    public void OutListOfFigures()
+    {
+        var options = new HtmlOut
+        {
+            ListOfFigures = true
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--list-of-figures"));
+    }
+
+    [Test]
+    public void OutListOfTables()
+    {
+        var options = new HtmlOut
+        {
+            ListOfTables = true
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--list-of-tables"));
+    }
+
+    [Test]
+    public void OutFigureCaptionPosition()
+    {
+        var options = new HtmlOut
+        {
+            FigureCaptionPosition = CaptionPosition.Above
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--figure-caption-position=above"));
+    }
+
+    [Test]
+    public void OutTableCaptionPosition()
+    {
+        var options = new HtmlOut
+        {
+            TableCaptionPosition = CaptionPosition.Below
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--table-caption-position=below"));
+    }
+
+    [Test]
+    public void OutSyntaxHighlighting()
+    {
+        var options = new HtmlOut
+        {
+            SyntaxHighlighting = "kate"
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--syntax-highlighting=kate"));
+    }
+
+    [Test]
+    public void HtmlEmailObfuscation()
+    {
+        var options = new HtmlOut
+        {
+            EmailObfuscation = EmailObfuscation.Javascript
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--email-obfuscation=javascript"));
+    }
+
+    [Test]
+    public void RstListTables()
+    {
+        var options = new RstOut
+        {
+            ListTables = true
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--list-tables"));
+    }
+
+    [Test]
+    public void PdfEngineOpt()
+    {
+        var options = new PdfOut
+        {
+            Engine = PdfEngine.XeLatex,
+            EngineOpt = "--shell-escape"
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--pdf-engine=xelatex"));
+        Assert.That(args, Does.Contain("--pdf-engine-opt=--shell-escape"));
+    }
+
+    [Test]
+    public void EpubSplitLevel()
+    {
+        var options = new Epub3Out
+        {
+            SplitLevel = 2
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--split-level=2"));
+    }
+
+    [Test]
+    public void EpubTitlePage()
+    {
+        var options = new Epub3Out
+        {
+            EpubTitlePage = false
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--epub-title-page=false"));
+    }
+
+    [Test]
+    public void ChunkedHtmlSplitLevel()
+    {
+        var options = new ChunkedHtmlOut
+        {
+            SplitLevel = 3
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--split-level=3"));
+    }
+
+    [Test]
+    public void ChunkedHtmlChunkTemplate()
+    {
+        var options = new ChunkedHtmlOut
+        {
+            ChunkTemplate = "%s-%i.html"
+        };
+
+        var args = options.GetArguments().ToList();
+
+        Assert.That(args, Does.Contain("--chunk-template=%s-%i.html"));
+    }
 }

--- a/src/input.include.md
+++ b/src/input.include.md
@@ -339,6 +339,12 @@ public abstract class InOptions
     /// </summary>
     public string? Abbreviations{ get; set; }
 
+    /// <summary>
+    /// Print diagnostic output tracing parser progress to stderr.
+    /// https://pandoc.org/MANUAL.html#option--trace
+    /// </summary>
+    public bool Trace { get; set; }
+
     protected abstract string Format { get; }
 
     public virtual IEnumerable<string> GetArguments()
@@ -357,7 +363,7 @@ public abstract class InOptions
 
         if (FileScope)
         {
-            yield return "file-scope";
+            yield return "--file-scope";
         }
 
         if (Filter != null)
@@ -401,6 +407,11 @@ public abstract class InOptions
         if (Abbreviations != null)
         {
             yield return $"--abbreviations={Abbreviations}";
+        }
+
+        if (Trace)
+        {
+            yield return "--trace";
         }
     }
 }

--- a/src/output.include.md
+++ b/src/output.include.md
@@ -166,6 +166,17 @@ public class BibTeXOut :
 ```
 
 
+#### CaptionPosition
+
+```cs
+public enum CaptionPosition
+{
+    Above,
+    Below
+}
+```
+
+
 #### ChunkedHtmlOut
 
 ```cs
@@ -176,6 +187,36 @@ public class ChunkedHtmlOut :
     OutOptions
 {
     public override string Format => "chunkedhtml";
+
+    /// <summary>
+    /// Specify the heading level at which to split into separate chunk files.
+    /// https://pandoc.org/MANUAL.html#option--split-level
+    /// </summary>
+    public int? SplitLevel { get; set; }
+
+    /// <summary>
+    /// Specify a template for the filenames in chunked HTML output.
+    /// https://pandoc.org/MANUAL.html#option--chunk-template
+    /// </summary>
+    public string? ChunkTemplate { get; set; }
+
+    public override IEnumerable<string> GetArguments()
+    {
+        foreach (var argument in base.GetArguments())
+        {
+            yield return argument;
+        }
+
+        if (SplitLevel != null)
+        {
+            yield return $"--split-level={SplitLevel}";
+        }
+
+        if (ChunkTemplate != null)
+        {
+            yield return $"--chunk-template={ChunkTemplate}";
+        }
+    }
 }
 ```
 
@@ -408,6 +449,18 @@ public class EmacsOrgOut :
 ```
 
 
+#### EmailObfuscation
+
+```cs
+public enum EmailObfuscation
+{
+    None,
+    Javascript,
+    References
+}
+```
+
+
 #### Eol
 
 ```cs
@@ -472,6 +525,18 @@ public class Epub2Out :
     /// </summary>
     public int? ChapterLevel { get; set; }
 
+    /// <summary>
+    /// Specify the heading level at which to split the EPUB into separate files.
+    /// https://pandoc.org/MANUAL.html#option--split-level
+    /// </summary>
+    public int? SplitLevel { get; set; }
+
+    /// <summary>
+    /// Determines whether a title page is included in the EPUB.
+    /// https://pandoc.org/MANUAL.html#option--epub-title-page
+    /// </summary>
+    public bool? EpubTitlePage { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -511,6 +576,14 @@ public class Epub2Out :
         if (SubDirectory != null)
         {
             yield return $"--epub-subdirectory={SubDirectory}";
+        }
+        if (SplitLevel != null)
+        {
+            yield return $"--split-level={SplitLevel}";
+        }
+        if (EpubTitlePage != null)
+        {
+            yield return $"--epub-title-page={EpubTitlePage.Value.ToString().ToLower()}";
         }
     }
 }
@@ -576,6 +649,18 @@ public class Epub3Out :
     /// </summary>
     public int? ChapterLevel { get; set; }
 
+    /// <summary>
+    /// Specify the heading level at which to split the EPUB into separate files.
+    /// https://pandoc.org/MANUAL.html#option--split-level
+    /// </summary>
+    public int? SplitLevel { get; set; }
+
+    /// <summary>
+    /// Determines whether a title page is included in the EPUB.
+    /// https://pandoc.org/MANUAL.html#option--epub-title-page
+    /// </summary>
+    public bool? EpubTitlePage { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -621,6 +706,16 @@ public class Epub3Out :
         if (SubDirectory != null)
         {
             yield return $"--epub-subdirectory={SubDirectory}";
+        }
+
+        if (SplitLevel != null)
+        {
+            yield return $"--split-level={SplitLevel}";
+        }
+
+        if (EpubTitlePage != null)
+        {
+            yield return $"--epub-title-page={EpubTitlePage.Value.ToString().ToLower()}";
         }
     }
 }
@@ -762,6 +857,12 @@ public class HtmlOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -817,6 +918,11 @@ public class HtmlOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }
@@ -1240,6 +1346,37 @@ public abstract class OutOptions
     public bool Sandbox { get; set; }
     public bool TableOfContents { get; set; }
     public int? TableOfContentsDepth { get; set; }
+
+    /// <summary>
+    /// Include an automatically generated list of figures.
+    /// https://pandoc.org/MANUAL.html#option--list-of-figures
+    /// </summary>
+    public bool ListOfFigures { get; set; }
+
+    /// <summary>
+    /// Include an automatically generated list of tables.
+    /// https://pandoc.org/MANUAL.html#option--list-of-tables
+    /// </summary>
+    public bool ListOfTables { get; set; }
+
+    /// <summary>
+    /// Specify where figure captions are placed relative to figures.
+    /// https://pandoc.org/MANUAL.html#option--figure-caption-position
+    /// </summary>
+    public CaptionPosition? FigureCaptionPosition { get; set; }
+
+    /// <summary>
+    /// Specify where table captions are placed relative to tables.
+    /// https://pandoc.org/MANUAL.html#option--table-caption-position
+    /// </summary>
+    public CaptionPosition? TableCaptionPosition { get; set; }
+
+    /// <summary>
+    /// Specify the method to use for code syntax highlighting.
+    /// https://pandoc.org/MANUAL.html#option--syntax-highlighting
+    /// </summary>
+    public string? SyntaxHighlighting { get; set; }
+
     public Eol? Eol { get; set; }
     public Wrap? Wrap { get; set; }
     public int? Dpi { get; set; }
@@ -1419,6 +1556,26 @@ public abstract class OutOptions
         {
             yield return $"--toc-depth={TableOfContentsDepth}";
         }
+        if (ListOfFigures)
+        {
+            yield return "--list-of-figures";
+        }
+        if (ListOfTables)
+        {
+            yield return "--list-of-tables";
+        }
+        if (FigureCaptionPosition != null)
+        {
+            yield return $"--figure-caption-position={FigureCaptionPosition.Value.ToString().ToLower()}";
+        }
+        if (TableCaptionPosition != null)
+        {
+            yield return $"--table-caption-position={TableCaptionPosition.Value.ToString().ToLower()}";
+        }
+        if (SyntaxHighlighting != null)
+        {
+            yield return $"--syntax-highlighting={SyntaxHighlighting}";
+        }
         if (StripComments)
         {
             yield return "--strip-comments";
@@ -1591,6 +1748,12 @@ public class RstOut :
     /// </summary>
     public bool ReferenceLinks { get; set; }
 
+    /// <summary>
+    /// Render tables as RST list tables.
+    /// https://pandoc.org/MANUAL.html#option--list-tables
+    /// </summary>
+    public bool ListTables { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -1601,6 +1764,11 @@ public class RstOut :
         if (ReferenceLinks)
         {
             yield return "--reference-links";
+        }
+
+        if (ListTables)
+        {
+            yield return "--list-tables";
         }
     }
 }
@@ -2298,6 +2466,12 @@ public class PdfOut :
     /// </remarks>
     public string? EnginePath { get; set; }
 
+    /// <summary>
+    /// Pass the given string as a command-line argument to the pdf-engine.
+    /// https://pandoc.org/MANUAL.html#option--pdf-engine-opt
+    /// </summary>
+    public string? EngineOpt { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -2312,6 +2486,11 @@ public class PdfOut :
         else if (Engine != null)
         {
             yield return $"--pdf-engine={Engine.Value.ToString().ToLower()}";
+        }
+
+        if (EngineOpt != null)
+        {
+            yield return $"--pdf-engine-opt={EngineOpt}";
         }
     }
 }
@@ -2518,6 +2697,12 @@ public class DzSlidesOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -2566,6 +2751,10 @@ public class DzSlidesOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }
@@ -2657,6 +2846,12 @@ public class RevealJsOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -2697,6 +2892,10 @@ public class RevealJsOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }
@@ -2760,6 +2959,12 @@ public class S5Out :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -2804,6 +3009,10 @@ public class S5Out :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }
@@ -2867,6 +3076,12 @@ public class SlideousOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -2911,6 +3126,10 @@ public class SlideousOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }
@@ -2974,6 +3193,12 @@ public class SlidyOut :
     /// </summary>
     public string? TitlePrefix { get; set; }
 
+    /// <summary>
+    /// Specify a method for obfuscating mailto: links in HTML documents.
+    /// https://pandoc.org/MANUAL.html#option--email-obfuscation
+    /// </summary>
+    public EmailObfuscation? EmailObfuscation { get; set; }
+
     public override IEnumerable<string> GetArguments()
     {
         foreach (var argument in base.GetArguments())
@@ -3023,6 +3248,10 @@ public class SlidyOut :
         if (TitlePrefix != null)
         {
             yield return $"--title-prefix={TitlePrefix}";
+        }
+        if (EmailObfuscation != null)
+        {
+            yield return $"--email-obfuscation={EmailObfuscation.Value.ToString().ToLower()}";
         }
     }
 }


### PR DESCRIPTION
Closes the gap between pandoc's CLI and PandocNet's typed API by adding all remaining options. Also fixes InOptions emitting "file-scope"  instead of "--file-scope".